### PR TITLE
Fix agent jobs order

### DIFF
--- a/newman-common/src/main/java/com/gigaspaces/newman/beans/CapabilitiesAndRequirements.java
+++ b/newman-common/src/main/java/com/gigaspaces/newman/beans/CapabilitiesAndRequirements.java
@@ -13,13 +13,6 @@ public class CapabilitiesAndRequirements {
         return jobs.stream().filter(job -> capabilities.containsAll(job.getSuite().getRequirements())).collect(Collectors.toList());
     }
 
-    public static Comparator<Job> requirementsSort = (job_1, job_2) -> {
-        int comp = job_2.getSuite().getRequirements().size() - job_1.getSuite().getRequirements().size();
-        if(comp == 0){
-            comp =  job_2.getId().compareTo(job_1.getId());
-        }
-        return comp;
-    };
 
     public static Set<String> parse(String input){
         Set<String> output =  new TreeSet<>();

--- a/newman-server/src/main/java/com/gigaspaces/newman/NewmanResource.java
+++ b/newman-server/src/main/java/com/gigaspaces/newman/NewmanResource.java
@@ -1804,22 +1804,12 @@ public class NewmanResource {
         }
         if (jobs != null && jobs.size() > 0) { // if found jobs with match requirements
             List<Job> jobsFilterByCapabilities = CapabilitiesAndRequirements.filterByCapabilities(jobs, capabilities); // filter jobs with not supported requirements
-            job = bestMatch(jobsFilterByCapabilities);
+            job = jobsFilterByCapabilities.get(0);
         }
         if (job == null) { // search for jobs without requirements
             Query<Job> noRequirementsQuery = basicQuery.cloneQuery();
             noRequirementsQuery.field("suite.requirements").doesNotExist();
             job = jobDAO.findOne(noRequirementsQuery);
-        }
-        return job;
-    }
-
-    private Job bestMatch(List<Job> jobsFilterByCapabilities) {
-        Job job = null;
-        List<Job> jobsGroupById = groupByBuild(jobsFilterByCapabilities);
-        if (jobsGroupById != null && !jobsGroupById.isEmpty()) { // if has jobs after filter
-            Collections.sort(jobsGroupById, CapabilitiesAndRequirements.requirementsSort);
-            job = jobsGroupById.get(0);
         }
         return job;
     }

--- a/newman-server/src/main/java/com/gigaspaces/newman/NewmanResource.java
+++ b/newman-server/src/main/java/com/gigaspaces/newman/NewmanResource.java
@@ -1814,12 +1814,6 @@ public class NewmanResource {
         return job;
     }
 
-    private List<Job> groupByBuild(List<Job> jobs) {
-        if (jobs.isEmpty()) return null;
-        String BuildId = jobs.get(0).getBuild().getId();
-        return jobs.stream().filter(job -> BuildId.equals(job.getBuild().getId())).collect(Collectors.toList());
-    }
-
     private Build getLatestBuild(String branch) {
         return buildDAO.findOne(buildDAO.createQuery().order("-buildTime").field("branch").equal(branch));
     }


### PR DESCRIPTION
The problematic line is:
Collections.sort(jobsGroupById, CapabilitiesAndRequirements.requirementsSort);
The sort was desc instead of asc (newest instead of oldest)

We don't need to group by build and sort again, we can just return the first one (the oldest)